### PR TITLE
删除 /verdor 下面的.gitignore 文件

### DIFF
--- a/vendor/.gitignore
+++ b/vendor/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
删除 /verdor下面的  .gitignore 文件后, /verdor 文件夹消失了
可能是由于 /verdor 为空, 自动消失,